### PR TITLE
Snap: pick up system theme and icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Linux/OSX/Windows installation packages download page is [here](https://github.c
   - On `Linux`: `python v2.7`, `make` and a C/C++ compiler toolchain, like `GCC` are most likely already installed. Besides [keytar](https://github.com/atom/node-keytar) needs `libsecret` library to be installed.
   - On `Mac OS X`: `python v2.7` and [Xcode](https://developer.apple.com/xcode/download/) need to be installed. You also need to install the `Command Line Tools` via Xcode, can be found under the `Xcode -> Preferences -> Downloads` menu.
 - [Clone](https://help.github.com/articles/cloning-a-repository/) this project to your local device. If you are going to contribute, consider cloning the [forked](https://help.github.com/articles/fork-a-repo/) into your own GitHub account project.
+- Install [Yarn](https://yarnpkg.com/en/docs/install).
 - Install dependencies running `yarn`.
 - Build app running `yarn run app:dist`. It's better to not touch a mouse during the process, since it might interfere with the `e2e` tests running at the end of the process.
 - Build a package to install running `yarn run electron-builder:dist` command to build Windows/Mac OS X package and one of the following commands to build Linux package:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -23,7 +23,7 @@ files: [
   "!node_modules/sodium-native/prebuilds/linux-arm",
   "!node_modules/sodium-native/prebuilds/win32-ia32",
   # TODO exclude not needed stuff in "files:" section to reduce app packages size, can save megabytes, so a significant improvement
-]
+ ]
 compression: maximum
 asar: true
 asarUnpack:
@@ -74,6 +74,10 @@ snap:
   plugs:
     - default
     - password-manager-service
+    # additional plugs to pick up the GTK theme and icons from the system, mouse cursor theme still not fixed
+    - { "gtk-3-themes": { "interface": "content", "target": "$SNAP/data-dir/themes", "default-provider": "gtk-common-themes:gtk-3-themes" }, }
+    - { "icon-themes": { "interface": "content", "target": "$SNAP/data-dir/icons", "default-provider": "gtk-common-themes:icon-themes" }, }
+    - { "sound-themes": { "interface": "content", "target": "$SNAP/data-dir/sounds", "default-provider": "gtk-common-themes:sounds-themes" }, }
   environment:
     DISABLE_WAYLAND: 1
 


### PR DESCRIPTION
Improvements to the snap package to use the system GTK theme and icons when available via snaps (like ambiance and yaru themes).

Previously the open dialogs to attach or save files had no icon and the standard adwaita GTK theme, see the attached screenshot:
![missing icons](https://user-images.githubusercontent.com/12795018/52917009-8236b100-32e6-11e9-9e9d-d426d7d35751.png)

After adding the right plugs it looks like this (using Yaru theme as used by other native apps):
![icon theme ok](https://user-images.githubusercontent.com/12795018/52917019-9d092580-32e6-11e9-9bd0-bb4ec9cc16d7.png)

One issue remains unresolved: the snap is using the fallback and ugly xcursor theme:
![ugly mouse theme](https://user-images.githubusercontent.com/12795018/52917032-cb870080-32e6-11e9-8639-776b39bd8012.png)

Many other snaps have this problem, after some investigation and trying different solutions, nothing appears to work. I guess, the snap technology still needs some improvements and will eventually get there...